### PR TITLE
0.37.3

### DIFF
--- a/public/css/temp.css
+++ b/public/css/temp.css
@@ -3,7 +3,7 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    color: #171515;
+    color: rgb(61, 61, 61);
   }
   
   /* Global styles */
@@ -334,8 +334,9 @@ h3 {
 .parksimg{
   display: block;
   margin: auto;
-  width: 600px; /* Change this value to the desired size */
-  height: 200px; /* Change this value to the desired size */
+  width: 800px; 
+  height: 200px; 
+  border-radius: 10px;
 }
 
 .container {
@@ -365,14 +366,24 @@ right: 10;
 }
 
 .reviewbox {
-  margin-left: 400px;
   border: solid 1px  rgb(61, 61, 61);
   border-radius: 5px;
   padding: 5px;
-  background-color: rgb(255, 255, 255)
+  background-color: rgb(134, 158, 138);
+  justify-content: center;
+  
 }
 
 .sig {
-  font-size: 11px;
-  color: rgb(43, 94, 149);
+  font-size: 17px;
+  font-weight: bold;
+}
+
+.hide{
+  display: hide;
+}
+
+.spageImage{
+  border-radius: 10px;
+  margin: 10px;
 }

--- a/seeds/parkdata.js
+++ b/seeds/parkdata.js
@@ -1,100 +1,17 @@
 const { Park } = require('../models')
-
+//-------------Park Data Alphabetized---------------
 const parkdata = [
-    {
-        name: 'Fort Mountain State Park',
-        county: 'Murray',
-        image: 'https://i0.wp.com/blueridgemountainstravelguide.com/wp-content/uploads/2022/03/Oerlook-at-Fort-Mountain-State-Park-near-Ellijay-GA-1-of-1.jpg?fit=1280%2C853&ssl=1',
-        content: `Fort Mountain State Park is a 3,712-acre Georgia state park located between Chatsworth and Ellijay on Fort Mountain. The state park was founded 
-        in 1938 and is named for an ancient 885-foot-long rock wall located on the peak`
-    },
-    {
-        name: 'Fort Yargo State Park',
-        county: 'Barrow',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/FortYargoVisitorsCenter2.jpg?itok=5ertD8Mo',
-        content: `Fort Yargo State Park is a 1,816-acre (7.35 km2) U.S. state park located in Winder, Georgia, situated between Athens and Atlanta. The park is located 1 mile south of Winder and is accessible by Georgia State Route 81. There is a 260-acre (1.1 km2) lake with a public beach. Available activities at Fort Yargo include GeoCaching, hiking, mountain biking, disc golf, boating (including Jon boat, pedal boat, and canoe rentals), 
-        lake swimming, fishing, picnicking, and miniature golf.`
-    },
-    {
-        name: 'General Coffee State Park',
-        county: 'Coffee',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/GeneralCoffee_0.jpg?itok=Qr554S7q',
-        content: `General Coffee State Park is a 1,511-acre (6.11 km2) Georgia state park located near Douglas. The park is named after politician, farmer, and military leader General John E. Coffee.[1] The park is host to many rare and endangered species, especially in the cypress swamps through which the Seventeen Mile River winds.`
-    },
-    {
-        name: 'George L. Smith State Park',
-        county: 'Emanuel',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/FortYargo2.jpg?itok=gWoeLTE6',
-        content: `George L. Smith State Park is a 1,634-acre (6.61 km2) Georgia state park located in Emanuel County. The park is named after George L. Smith, a former speaker of the Georgia House of Representatives and Emanuel County native. Attractions include a grist mill, 
-        covered bridge, and the dam of the Parrish Mill (built 1880).`
-    },
-    {
-        name: 'George T. Bagby State Park',
-        county: 'Clay',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/GeorgeTBagby3.jpg?itok=ruyGf2-n',
-        content: `George T. Bagby State Park is a 700-acre (280 ha) state park located in southwestern Georgia on the shore of Walter F. George Lake. The park offers a 60-room lodge, conference center, restaurant, cottages, and features the 
-        18 hole Meadow Links Golf Course, as well as a marina and boat ramp.`
-    },
-    {
-        name: 'Georgia Veterans State Park',
-        county: 'Crisp',
-        image: 'https://gastateparks.org/sites/default/files/parks/images/webmaps/webmap-2023-02.png',
-        content: `Georgia Veterans State Park (originally the Georgia Veterans Memorial State Park) is a state park located on Lake Blackshear in Crisp County, west of Cordele, Georgia. It was established on December 4, 1946 as a memorial to U.S. Veterans. The 1,308-acre (5 km2) park features a museum with aircraft, vehicles, 
-        weapons, uniforms and other memorabilia dating from the Revolutionary War to the present.`
-    },
-    {
-        name: 'Hamburg State Park',
-        county: 'Warren',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/hamburg-slider1.jpg?itok=oLjWvsxu',
-        content: `Hamburg State Park is a 741 acre (3.00 km²) state park located near Jewell and Warthen in the U.S. state of Georgia. It is home to a 1921 water-powered grist mill still operating today, and a museum with 
-        antique agricultural tools and appliances used in rural Georgia.`
-    },
-    {
-        name: 'Hard Labor Creek State Park',
-        county: 'Morgan',
-        image: 'https://gastateparks.org/HardLaborCreek',
-        content: `Hard Labor Creek State Park is a 5,804 acre (23.49 km²) Georgia state park located between Bostwick and Rutledge. The park is named after Hard Labor Creek, a small stream that cuts through the park. The creek's name comes either from enslaved people who once tilled the summer fields, or from Native
-         Americans who found the area around the stream difficult to ford.`
-    },
-    {
-        name: 'High Falls State Park',
-        county: 'Monroe',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/HighFalls.jpg?itok=sX_97ZV_',
-        content: `High Falls State Park is a 1,050-acre (4.2 km2) Georgia state park located near the city of Jackson in Monroe County, Georgia, part of the Macon metropolitan area.
-         It is the site of a prosperous 19th-century industrial center, which became a ghost town when it was bypassed by the railroad. The park contains the largest waterfall in middle Georgia and a 650-acre (2.6 km2) lake.`
-    },
-    {
-        name: 'Indian Springs State Park',
-        county: 'Butts',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/indian-springs-slider-stairs_0.jpg?itok=h1pfeKTL',
-        content: `Indian Springs State Park is a 528-acre (2.14 km²) Georgia state park located near Jackson and Flovilla. The park is named for its several springs, which the Creek Indians used for centuries to heal the sick. The water from these springs is said to have a sulfur smell and taste. Indian Springs is 
-        thought to be the oldest state park in the nation.`
-    },
-    {
-        name: 'Jack Hill State Park',
-        county: 'Tattnall',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/banner-jackhill-footgolf.jpg?itok=ob6u4nLB',
-        content: `Jack Hill State Park, formerly named Gordonia-Alatamaha State Park, is a 662-acre (268 ha) Georgia state park located in Reidsville, a city on Georgia's coastal plain region. The park is known for having a dramatic history, 
-        having been previously under water for nearly 20 million years.`
-    },
-    {
-        name: 'James H. Floyd State Park',
-        county: 'Chattooga',
-        image: 'https://d3qvqlc701gzhm.cloudfront.net/thumbs/fd9b3b4c78f9c4c4fb05832764862244c304dc46ff0e30a126b94aa9f1dd7856-375.jpg',
-        content: `James H. Floyd State Park is a 561-acre (2.27 km²) Georgia State Park located near Summerville at the base of Taylor Ridge (Georgia). The park is named after Democrat James H. "Sloppy" Floyd who served in the 
-        Georgia House of Representatives from 1953 until 1974 and was from the area.`
-    },
     {
         name: 'Amicalola Falls State Park & Lodge',
         county: 'Dawson',
-        image: 'https://www.amicalolafallslodge.com/wp-content/uploads/2019/07/amicalola-header-blog.jpg',
+        image: 'https://www.amicalolafallslodge.com/wp-content/uploads/2019/03/FallsHeader.jpg',
         content: `Amicalola Falls State Park & Lodge has four groups of trails within it, 
         including the trail leading up to the top of the waterfall. The park has a lodge that serves as a starting point for Appalachian Trail hikers. The park also checks in guests for a nearby facility called the Len Foote Hike Inn, a backcountry eco-friendly inn that is 5 miles from the park, one mile from the Appalachian Approach trail and 4.4 miles from Springer Mountain.`
     },
     {
         name: 'Black Rock Mountain State Park',
         county: 'Rabun',
-        image: 'https://d3qvqlc701gzhm.cloudfront.net/full/6c34cb0554f4d622cd08e6e4222779c0de3e86e8503b5b5d77689d8a5b003ce8.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/BlackRockMountain1.jpg?itok=gWnK34qZ',
         content: `Black Rock Mountain State Park is a 1,743-acre (705 ha) Georgia, United States, state park west of Mountain City in Rabun County, in the Blue Ridge Mountains. It is named after its sheer cliffs of dark-colored biotite gneiss. Astride the Eastern Continental Divide at an elevation of 3,640 feet (1,110 m), the park provides many scenic overlooks and 80-mile (130 km) vistas of the southern Appalachian Mountains. On a clear day, four states are visible: Georgia, North Carolina, South Carolina, and Tennessee. In addition to Black Rock Mountain itself, the park includes four other peaks over 3,000 feet (910 m) in elevation, making it the state's highest state park. As of 2019, it was open to visitors year round.`
     },
     {
@@ -147,99 +64,158 @@ const parkdata = [
         content: `Florence Marina State Park is a 45,000-acre state park located at the northern end of Lake Walter F. George (also called Lake Eufaula). It was once home to Native Americans and the old town of Florence. Visitors can experience its agricultural and commercial past by walking forested trails, visiting the Kirbo Interpretive Center, or fishing from its natural deep-water marina.`
     },
     {
-        name: 'Fort King George State Historic Site',
-        county: 'McIntosh',
-        image: 'https://imgs.search.brave.com/JK8x8QCLboIjbc0ftcc8cjaraWq1mpR8ihGj7tuJDp4/rs:fit:550:413:1/g:ce/aHR0cHM6Ly9tZWRp/YS1jZG4udHJpcGFk/dmlzb3IuY29tL21l/ZGlhL3Bob3RvLXMv/MWEvZTMvMTcvOGEv/Zm9ydHJlc3MuanBn',
-        content: `Fort King George State Historic Site is located in McIntosh County, adjacent to Darien. It was built in 1721 along what is now known as the Darien River and served as the southernmost outpost of the British Empire in North America from 1721 until 1736.3 A cypress blockhouse, barracks and palisaded earthen fort were constructed by scoutmen led by Colonel John “Tuscarora Jack” Barnwell during this time period.124 It is the oldest English fort remaining on Georgias coast.`
-    },
-    {
         name: 'Fort McAllister State Park',
         county: 'Bryan',
         image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/FortMcAllister-banner4.jpg?itok=-VOhODK6',
         content: `Fort McAllister State Park is located close to I-95 south of Savannah on the banks of the Ogeechee River. It showcases the best-preserved earthwork fortification of the Confederacy, which was attacked seven times by Union ironclads but did not fall until 1864—ending General William T. McAllister's presidency. The park has been connected to Native American life, Civil War soldiers and Henry Ford Era visitors for centuries.`
     },
     {
-        name: 'Fort Morris State Historic Site',
-        county: 'Liberty',
-        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/FortMorris.jpg?itok=6GcKOQP4',
-        content: `Fort Morris State Historic Site was originally a Guale Indian village and became the seaport town of Sunbury in 1776. During both the Revolutionary War and the War of 1812, Fort Morris was used as a coastal fortification to protect Georgia's coast. The earthen works were reconstructed during this time.`
+        name: 'Fort Mountain State Park',
+        county: 'Murray',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/locationslideshow/FortMountain.jpg?itok=5EKTscvg',
+        content: `Fort Mountain State Park is a 3,712-acre Georgia state park located between Chatsworth and Ellijay on Fort Mountain. The state park was founded 
+        in 1938 and is named for an ancient 885-foot-long rock wall located on the peak`
     },
     {
-        name: 'Jefferson Davis Memorial Historic Site',
-        county: 'Irwin',
-        image: 'https://parks.ky.gov/sites/default/files/listing_images/profile/19/28af31ced514e722f68bf95278db81e9_sliderjeffdavismonument.jpg',
-        content: `Jefferson Davis Memorial Historic Site is a 12.668-acre state historic site located in Irwin County, Georgia that marks the spot where Confederate States President Jefferson Davis was captured by United States Cavalry on Wednesday, May 10, 1865. The historic site features a granite monument with a bronze bust of Davis that is located at the place of capture.The memorial museum, built in 1939 by the Works Progress Administration, features Civil War era weapons, uniforms, artifacts and an exhibit about the president's 1865 flight from Richmond, Virginia to Irwin County, Georgia.`
+        name: 'Fort Yargo State Park',
+        county: 'Barrow',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/FortYargoVisitorsCenter2.jpg?itok=5ertD8Mo',
+        content: `Fort Yargo State Park is a 1,816-acre (7.35 km2) U.S. state park located in Winder, Georgia, situated between Athens and Atlanta. The park is located 1 mile south of Winder and is accessible by Georgia State Route 81. There is a 260-acre (1.1 km2) lake with a public beach. Available activities at Fort Yargo include GeoCaching, hiking, mountain biking, disc golf, boating (including Jon boat, pedal boat, and canoe rentals), 
+        lake swimming, fishing, picnicking, and miniature golf.`
+    },
+    {
+        name: 'General Coffee State Park',
+        county: 'Coffee',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/GeneralCoffee_0.jpg?itok=Qr554S7q',
+        content: `General Coffee State Park is a 1,511-acre (6.11 km2) Georgia state park located near Douglas. The park is named after politician, farmer, and military leader General John E. Coffee.[1] The park is host to many rare and endangered species, especially in the cypress swamps through which the Seventeen Mile River winds.`
+    },
+    {
+        name: 'George L. Smith State Park',
+        county: 'Emanuel',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/FortYargo2.jpg?itok=gWoeLTE6',
+        content: `George L. Smith State Park is a 1,634-acre (6.61 km2) Georgia state park located in Emanuel County. The park is named after George L. Smith, a former speaker of the Georgia House of Representatives and Emanuel County native. Attractions include a grist mill, 
+        covered bridge, and the dam of the Parrish Mill (built 1880).`
+    },
+    {
+        name: 'George T. Bagby State Park',
+        county: 'Clay',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/GeorgeTBagby3.jpg?itok=ruyGf2-n',
+        content: `George T. Bagby State Park is a 700-acre (280 ha) state park located in southwestern Georgia on the shore of Walter F. George Lake. The park offers a 60-room lodge, conference center, restaurant, cottages, and features the 
+        18 hole Meadow Links Golf Course, as well as a marina and boat ramp.`
+    },
+    {
+        name: 'Georgia Veterans State Park',
+        county: 'Crisp',
+        image: 'https://www.lakeblackshearresort.com/wp-content/uploads/2021/05/Lake-Blackshear-Homepage-Slider-MarinaSunset.jpg?t=1681240335725',
+        content: `Georgia Veterans State Park (originally the Georgia Veterans Memorial State Park) is a state park located on Lake Blackshear in Crisp County, west of Cordele, Georgia. It was established on December 4, 1946 as a memorial to U.S. Veterans. The 1,308-acre (5 km2) park features a museum with aircraft, vehicles, 
+        weapons, uniforms and other memorabilia dating from the Revolutionary War to the present.`
+    },
+    {
+        name: 'Hamburg State Park',
+        county: 'Warren',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/hamburg-slider1.jpg?itok=oLjWvsxu',
+        content: `Hamburg State Park is a 741 acre (3.00 km²) state park located near Jewell and Warthen in the U.S. state of Georgia. It is home to a 1921 water-powered grist mill still operating today, and a museum with 
+        antique agricultural tools and appliances used in rural Georgia.`
+    },
+    {
+        name: 'Hard Labor Creek State Park',
+        county: 'Morgan',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/HardLaborCreek_0.jpg?itok=SzYx4PC2',
+        content: `Hard Labor Creek State Park is a 5,804 acre (23.49 km²) Georgia state park located between Bostwick and Rutledge. The park is named after Hard Labor Creek, a small stream that cuts through the park. The creek's name comes either from enslaved people who once tilled the summer fields, or from Native
+         Americans who found the area around the stream difficult to ford.`
+    },
+    {
+        name: 'High Falls State Park',
+        county: 'Monroe',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/HighFalls.jpg?itok=sX_97ZV_',
+        content: `High Falls State Park is a 1,050-acre (4.2 km2) Georgia state park located near the city of Jackson in Monroe County, Georgia, part of the Macon metropolitan area.
+         It is the site of a prosperous 19th-century industrial center, which became a ghost town when it was bypassed by the railroad. The park contains the largest waterfall in middle Georgia and a 650-acre (2.6 km2) lake.`
+    },
+    {
+        name: 'Indian Springs State Park',
+        county: 'Butts',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/indian-springs-slider-stairs_0.jpg?itok=h1pfeKTL',
+        content: `Indian Springs State Park is a 528-acre (2.14 km²) Georgia state park located near Jackson and Flovilla. The park is named for its several springs, which the Creek Indians used for centuries to heal the sick. The water from these springs is said to have a sulfur smell and taste. Indian Springs is 
+        thought to be the oldest state park in the nation.`
+    },
+    {
+        name: 'Jack Hill State Park',
+        county: 'Tattnall',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/banner-jackhill-footgolf.jpg?itok=ob6u4nLB',
+        content: `Jack Hill State Park, formerly named Gordonia-Alatamaha State Park, is a 662-acre (268 ha) Georgia state park located in Reidsville, a city on Georgia's coastal plain region. The park is known for having a dramatic history, 
+        having been previously under water for nearly 20 million years.`
+    },
+    {
+        name: 'James H. Floyd State Park',
+        county: 'Chattooga',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/JamesHFloyd.jpg?itok=WW7ogu9q',
+        content: `James H. Floyd State Park is a 561-acre (2.27 km²) Georgia State Park located near Summerville at the base of Taylor Ridge (Georgia). The park is named after Democrat James H. "Sloppy" Floyd who served in the 
+        Georgia House of Representatives from 1953 until 1974 and was from the area.`
     },
     {
         name: 'Kolomoki Mounds',
         county: 'Early',
-        image: 'https://upload.wikimedia.org/wikipedia/commons/b/b3/Kolomoki-temple-mound.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/KolomokiMounds_0.jpg?itok=UJpPVa-r',
         content: `The Kolomoki Mounds is one of the largest and earliest Woodland period earthwork mound complexes in the Southeastern United States[3] and is the largest in Georgia. Constructed from 350CE to 600CE, the mound complex is located in southwest Georgia, in present-day Early County near the Chattahoochee River.`
     },
     {
         name: 'Laura S. Walker State Park',
         county: 'Ware',
-        image: 'https://gastateparks.reserveamerica.com/webphotos/GA/pid530177/0/540x360.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/LSW-banner1.jpg?itok=zQj9XaDL',
         content: `Laura S. Walker State Park is a 626-acre state park in the U.S. state of Georgia. Located near Hoboken and the Okefenokee Swamp, the park is named after Laura S. Walker, a Georgia writer, teacher, civic leader, and naturalist . The park's location near the Okefenokee makes it home to many exotic plant and animal species, including alligators, great blue herons, and pitcher plants. The park includes a 120-acre lake and a championship 18-hole golf course with a pro shop.`
     },
     {
         name: 'Little Ocmulgee State Park',
         county: 'Telfair',
-        image: 'https://www.littleocmulgeelodge.com/wp-content/uploads/2019/06/state-park-grid-Lake-8990.jpg',
+        image: 'https://www.littleocmulgeelodge.com/wp-content/uploads/2019/06/Lake-8990.jpg',
         content: `Little Ocmulgee State Park and Lodge is a 1,360-acre Georgia state park located 2 miles north of McRae-Helena on the Little Ocmulgee River. Part of the park was initially built by the Civilian Conservation Corps during the Great Depression, around the natural diversion of the Little Ocmulgee into a lake. This is a 256-acre lake with beach, and the park includes a 60 room lodge and a championship 18-hole golf course with pro shop, known as the Wallace Adams Memorial Golf Course.[1] The soil around the Ocmulgee River and the Little Ocmulgee is a fine white sand, and therefore the lake has its own "beach sand". Also within the park is the 2.6-mile long Oak Ridge Trail, allowing visitors to see native wildlife and plants.`
     },
     {
         name: 'Magnolia Springs State Park',
         county: 'Jenkins',
-        image: 'https://www.georgiaencyclopedia.org/wp-content/uploads/2021/02/magnolia-springs-state-park_001.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/mag-slider.jpg?itok=SwTHFBhh',
         content: `Magnolia Springs State Park is a 1,070-acre Georgia state park located between Perkins and Millen in Jenkins County. The park was built as a project of the Civilian Conservation Corps and opened in 1939. The park is well known for its crystal clear springs that are estimated to flow 7 million US gallons per day. The park also offers unique wildlife near the springs, including alligators, turtles, and a variety of birds and fish.`
     },
     {
         name: 'Mistletoe State Park',
         county: 'Columiba',
-        image: 'https://d3qvqlc701gzhm.cloudfront.net/thumbs/f139ecf4501da037df68c7c42525ad435fbc4b9d23a3c08e2c520b1256115f29-750.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/Mistletoe.jpg?itok=U80NPnmI',
         content: `Mistletoe State Park is a 1,972 acre Georgia state park located northwest of Augusta, Georgia on the southern shore of Lake Strom Thurmond. The park gets its name from Mistletoe Corners,[1] a local area where people gather to pick mistletoe during the winter holiday season. Its strategic location on the lake makes it one of the finest bass fishing spots in the nation. The park also offers public beaches and 8 miles of nature trails. The land on which the park is located is leased to Georgia by the United States Army Corps of Engineers.`
     },
     {
         name: 'Moccasin Creek State Park',
         county: 'Rabun',
-        image: 'https://blueridgemountainstravelguide.com/wp-content/uploads/2021/03/Lake-Burton-Boathouse-at-Moccasin-Creek-State-Park.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/MoccasinCreek_0.jpg?itok=qTnsCKf2',
         content: `Moccasin Creek State Park is a 32-acre state park located on the western shore of Lake Burton in Rabun County in the northeast corner of Georgia. The park features campgrounds; a fishing pier for the physically disabled, the elderly, and children; and walking trails. Even though the surrounding area is mountainous, the camping area is relatively flat.`
     },
     {
         name: 'Panola Mountain',
         county: 'Henry',
-        image: 'https://www.atlantatrails.com/wp-content/uploads/2018/01/panola-mountain-state-park-03.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/panola-mountain-rock-banner_0.jpg?itok=16sO6Bxf',
         content: `Panola Mountain is a 100-acre granite monadnock near Stockbridge on the boundary between Henry County and Rockdale County, Georgia. The peak is 946 feet above sea level, rising 260 feet above the South River. The South River marks the boundary between Henry, Rockdale, and DeKalb counties. Due to its delicate ecological features, Panola Mountain was designated a National Natural Landmark in 1980`
-    },
-    {
-        name: 'Picketts Mill Battlefield Site',
-        county: 'Paulding',
-        image: 'https://www.georgiaencyclopedia.org/wp-content/uploads/2021/02/battle-of-picketts-mill_003.jpg',
-        content: `Pickett's Mill Battlefield Site is a Georgia state park in Paulding County, Georgia that preserves the American Civil War battlefield of the Battle of Pickett's Mill. The 765-acre site includes roads used by Union and Confederate troops, earthwork battlements, and an 1800s era pioneer cabin. The area's ravine is a site where hundreds died. The park's visitor center includes exhibits and a film about the battle.`
     },
     {
         name: 'Providence Canyon State Park',
         county: 'Steward',
-        image: 'https://365atlantatraveler.com/wp-content/uploads/2022/05/Providence-Canyon.jpeg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/ProvidenceCanyon.jpg?itok=GS3mXVXI',
         content: `Providence Canyon State Outdoor Recreation Area is a 1,003-acre Georgia state park located in Stewart County in southwest Georgia, United States.[2] The park contains Providence Canyon, which is sometimes called Georgia's "Little Grand Canyon". It is considered one of the Seven Natural Wonders of Georgia. It is also home to the very rare plumleaf azalea.`
     },
     {
         name: 'Red Top Mountain State Park',
         county: 'Bartow',
-        image: 'https://acworthtourism.org/wp-content/uploads/2021/10/red-top-lake-allatoona.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/RedTopMountain.jpg?itok=a4s7cj6i',
         content: `Red Top Mountain State Park is a state park in the U.S. state of Georgia. It is located in the northwestern part of the state, on the northwestern edge of metro Atlanta, in southeastern Bartow County near Cartersville. Named for iron-rich Red Top Mountain,[1] the park covers 1,776 acres on a peninsula jutting north into Lake Allatoona, formed on the park's north and east sides by the Etowah River arm and on the west by Allatoona Creek arm.`
     },
     {
         name: 'Reed Bingham State Park',
         county: 'Colquitt',
-        image: 'https://friendsofgastateparks.org/sites/default/files/import/field/image/ReedBingham-042614-0534-X2.jpg',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/ReedBingham1.jpg?itok=V9s8Co7N',
         content: `Reed Bingham State Park is a 1,613 acre Georgia state park in Colquitt County and Cook County located 5 miles east of Ellenton. The park surrounds a 375 acre lake that is a tourist attraction in southern Georgia. Inside the park, visitors can hike the 3.5 mile long Coastal Plains Nature Trail, which goes through a baldcypress swamp, a pitcher plant bog, and sandhill area. The park also contains many animals, including the threatened gopher tortoise and the indigo snake. In addition, the park offers camping and fishing with special ponds for kids that are only open on specific dates.`
     },
     {
         name: 'richard b. russell state park',
         county: 'Elbert',
-        image: 'https://api.trekaroo.com/system/photos/189109/original/2014-03-20_18.05.24.jpg?1493798311',
+        image: 'https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/RichardBRussell1.jpg?itok=Wm62qRzX',
         content: `Richard B. Russell State Park is a 2,508 acres state park located on the shore of Richard B. Russell Lake in Elbert County, Georgia. The park features the 18-hole Arrowhead Golf Course, as well as picnic shelters and a swimming beach.`
     },
     {
@@ -257,7 +233,7 @@ const parkdata = [
         {
         name: "Smithgall Woods State Park",
         county: "White",
-        image: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQh1eyUDf2vUjl5URp4KtWnmvF8armkcmNuQQ&usqp=CAU",
+        image: "https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/SmithgallWoods1.jpg?itok=VMH1fLHC",
         content:"Smithgall Woods Conservation Area and Lodge is a 5,664 acres (8.85 sq mi; 22.92 km2) Georgia state park, lodge and protected wilderness area near Helen, Georgia. It contains old growth forests, 12 miles of trout streams, and populations of wild turkeys, bears and deer."
         },
         {
@@ -269,13 +245,13 @@ const parkdata = [
         {
         name: "Stephen C. Foster State Park",
         county: "Charlton",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Cypresses_on_the_water.jpg/330px-Cypresses_on_the_water.jpg",
+        image: "https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/StephenCFoster.jpg?itok=BSgcWWv0",
         content:"Stephen C. Foster State Park is an 120-acre (49 ha) state park located in the Okefenokee Swamp in Charlton County, Georgia. the park offers visitors several ways to explore the swamp's unique ecosystem"
         },
         {
         name: "Sweetwater Creek State Park",
         county: "Douglas",
-        image: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQO9zwp9VPWUleJSNdlwRTfZslvDO-xcxQCvw&usqp=CAU",
+        image: "https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/SweetwaterCreek.jpg?itok=mMh9uwKn",
         content:"Sweetwater Creek State Park is a 2,549 acres (10.32 km2) Georgia state park in east Douglas County, 15 miles (24 km) from downtown Atlanta. The park is named after Sweetwater Creek which runs through it. The park features wooded walking and hiking trails, the George Sparks Reservoir, a visitor center, a bait shop, and a gift shop, as well as the ruins of the New Manchester Manufacturing Company."
         },
         {
@@ -287,42 +263,38 @@ const parkdata = [
         {
         name: "Tugaloo State Park",
         county: "Franklin",
-        image: "https://upload.wikimedia.org/wikipedia/en/thumb/3/3a/Tugaloo_State_Park_Beach.jpg/750px-Tugaloo_State_Park_Beach.jpg",
+        image: "https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/Tugaloo.jpg?itok=67ac2eDE",
         content: "Tugaloo State Park is a 393 acres (1.59 km2) state park located on the shore of Lake Hartwell in Franklin County, Georgia. The park features a swimming beach, boat ramps, and ample fishing opportunities, and is located near S.R. 328 north of Lavonia."
         },
         {
         name: "Unicoi State Park & Lodge",
         county: "White",
-        image: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSSHrhe57jIfMjN6YeLJpZoITgGtiMLIpj9zKM-5Dt0xA&s",
+        image: "https://www.unicoilodge.com/wp-content/uploads/2017/06/1600x800-Level2Ziplines.jpg?t=1681241213146",
         content:"Unicoi State Park & Lodge is a 1,050-acre (4.2 km2) state park (est. in 1954) located immediately north-northeast of Helen, Georgia in the northeastern portion of the state. The centerpiece of the park is 53-acre (21 ha) Unicoi Lake on Smith Creek. The park is especially popular in October, when the autumn leaves in the forest change colors."
         },
         {
         name: "Victoria Bryant State Park",
         county: "Franklin",
-        image: "https://gastateparks.reserveamerica.com/webphotos/GA/pid530200/0/",
+        image: "https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/VictoriaBryant1.jpg?itok=rI3h-HCO",
         content:"Victoria Bryant State Park is a 502-acre (2.03 km2) Georgia state park located near Franklin Springs.[1] Nestled in the rolling hills of Georgia's Piedmont plateau, this park offers facilities ranging from picnic sites and a swimming pool to an 18-hole golf course. The North Fork of the Broad River flows through the park, adding several water hazards to the course"
         },
         {
         name: "Vogel State Park",
         county: "Union",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/7/7f/Lake_Trahlyta%2C_Vogel_State_Park%2C_Oct_2016_1.jpg/1920px-Lake_Trahlyta%2C_Vogel_State_Park%2C_Oct_2016_1.jpg",
+        image: "https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/Vogel.jpg?itok=ADP5wlyB",
         content: "Vogel State Park is located in the north Georgia mountains and offers visitors a chance to experience the beauty of the area. The park features hiking trails, a lake for fishing and boating, picnic areas, and campsites for overnight stays. Vogel State Park is a popular destination for families and outdoor enthusiasts alike."
         },
         {
         name: "Watson Mill Bridge State Park",
         county: "Madison",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Watson_mill_state_park.jpg/2560px-Watson_mill_state_park.jpg",
+        image: "https://gastateparks.org/sites/default/files/styles/locationslidestyle/public/parks/locationslideshow/WatsonMillBridge.jpg?itok=qXrdiR8q",
         content: "Watson Mill Bridge State Park is home to one of the longest and tallest covered bridges in Georgia. The park features hiking trails, picnic areas, and campsites for visitors to enjoy. Visitors can also fish in the nearby river or take a guided horseback ride through the park. Watson Mill Bridge State Park is a great place to relax and enjoy the natural beauty of Georgia."
         }
 
 
-    
-
-
-
-
-
 ];
+
+
 
 const parkSeeds = () => Park.bulkCreate(parkdata)
 

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -1,16 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Georgia State Parks Comment and Review Spot</title>
-   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
-   <link rel="stylesheet" href="../css/temp.css">
-</head>
-<body class="bodystyle">
-  <div class="container">
-  <h1 class="headerstyle">Georgia on Your Mind?</h1>
-  <h2 class="headerstyle">Georgia State Parks Comment and Review Spot</h2>
+<div class="container">
+  <br>
+  <h1 class="headerstyle">Parkify</h1>
+  <h2 class="headerstyle">Georgia State Parks Review Hub</h2>
  <br>
  <br>
+ 
 
   {{!-- <div class="image-container">
     <img src="https://gastateparks.org/sites/default/files/parks/images/webmaps/webmap-2023-02.png" alt="Map of Georgia state parks" class="img-fluid">
@@ -20,12 +14,12 @@
     <div>
       {{#each parks as | park|  }}
       <div class="container">
-          <div class="row justify-content-center">
         <a href="/park/{{park.id}}">
         <h2 class="text-center">{{park.name}} </h2> 
         </a>
-        <div class="text-center font-weight-bold">{{park.county}} </div>
+        <div class="text-center font-weight-bold">County: {{park.county}} </div>
         <img class="parksimg" src="{{park.image}}">
+        <br>
         <p class="col-md-6" >{{park.content}} </p>
           </div>
       </div>
@@ -33,5 +27,4 @@
       <br>  
     {{/each}}
     </div>
-  <script src="../js/logout.js"> 
-  </script>
+

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -2,13 +2,13 @@
   <head>
     <title>Basic Web Page</title>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="../css/temp.css" rel="stylesheet" />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/css/bootstrap.min.css"
       integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
       crossorigin="anonymous"
     />
+      <link href="../css/temp.css" rel="stylesheet" />
   </head>
   <body>
 
@@ -39,7 +39,8 @@
                   id="logOut"
                 >logout</button>
               {{else}}
-                <a href="/login" class="btn btn-secondary">login</a>
+                <a href="/login" class="btn btn-secondary">Log In</a>
+                <a href="/signup" class="btn btn-secondary">Sign up</a>
               {{/if}}
             </li>
           </ul>
@@ -48,4 +49,7 @@
     </nav>
     {{{body}}}
   </body>
+    <script src="../js/logout.js"> </script>
+    <script src="../js/review.js"></script> 
+    <script src="../js/script.js"></script>
 </html>

--- a/views/singlepark.handlebars
+++ b/views/singlepark.handlebars
@@ -1,27 +1,14 @@
 <div>
 <div class="container">
       <h2 class="text-center">{{name}} </h2>
-      <div class="text-center">{{county}} </div>
-      <img class="text-center" src="{{image}}">
+      <div class="text-center">County: {{county}} </div>
+      <img class="spageImage text-center" src="{{image}}">
       <p class="text-center"> {{content}} </p>
-    </div>
-
-  {{#each review as |review|}}
-    <div class="reviewbox col-6">
-      <p class="text-center">{{review.rating}}</p>
-      <p class="text-center">{{review.content}}</p>
-      <div class="sig"> 
-      <p class="text-center"> {{review.user_name}}</p>
-      </div>
-    </div>
-    <br>
-  {{/each}}
+</div>
 
  {{#if loggedIn}}
-  <div class="row">
-  <div class="mx-auto col-10 col-md-8 col-lg-6">
+ <div class="text-center">
   <form class="col-md-8">
-
   <div class="form-group">
     <label for="rating">Rating</label>
     <select class="form-control" id="rating">
@@ -34,16 +21,33 @@
   </div>
   <div class="form-group">
     <label for="review">Review</label>
-    <textarea class="form-control" id="reviewContent" rows="10"></textarea>
+    <textarea class="form-control" id="reviewContent" rows="8"></textarea>
   </div>
   <button type="submit" class="btn btn-primary" id="newReview">Submit</button>
 </form>
+ </div>
 </div>
 </div>
     {{else}}
-      <h2> <a href="/login">Log in</a> to leave a review </h2>
+      <h2 class="text-center"> <a href="/login">Log in</a> to leave a review </h2>
     {{/if}}
 
-</div>
+<br>
+<h2 class="text-center">Park Reviews </h2>
+<div class="text-center">
+  {{#each review as |review|}}
+    <div class=" container reviewbox col-8">
+      <br>
+       <div class="sig"> 
+      <p class="text-center"> User:{{review.user_name}}</p>
+      </div>
+      <p class="text-center">Rating: {{review.rating}}</p>
+      <p class="text-center">Description: {{review.content}}</p>
+    </div>
+    <br>
+  {{/each}}
+  </div>
 
- <script src="../js/review.js"></script> 
+
+
+</div>


### PR DESCRIPTION
on main.handlebars I fixed the order of the stylesheets by putting the bootstrap link over the css sheet so  styling wont interfere. I also added a sign up button to the nav bar when the user is logged out. For the singlepark.handlebars I changed the order of the park reviews and the review form by putting the review form over the park reviews for a better user experience. for the main.handlebars page I fixed a lot of bootstrap errors and class names and I got rid of head and html tags which werent supposed to be there. On the temp.css I added styling to the homepage and main.handlebar pages. Lastly for the parkData.js I fixed some of the image links, I put it in alphabetical order by name, and I deleted some historic sites that were not supposed to be there.